### PR TITLE
fix doc internals.rst, Reader example

### DIFF
--- a/docs/internals.rst
+++ b/docs/internals.rst
@@ -44,6 +44,11 @@ method that returns HTML content and some metadata.
 
 Take a look at the Markdown reader::
 
+    try:
+        from markdown import Markdown
+    except ImportError:
+        Markdown = False  # NOQA
+
     class MarkdownReader(BaseReader):
         enabled = bool(Markdown)
 


### PR DESCRIPTION
add try/except statement showing where the var Markdown comes from
